### PR TITLE
avoid warning on 5.17.1

### DIFF
--- a/script/uniprops
+++ b/script/uniprops
@@ -689,11 +689,11 @@ sub load_properties() {
 
     0 and s/ ^ \s+ [DSX] \s+ .* \n//gmx;
 
-    my $prop_rx = qr{
+    my $prop_rx = qr<
         \\ p \{
             (?<PROPNAME> [\w\s\-.:=] + )
         \}
-    }x;
+    >x;
 
     while (/$prop_rx/g) {
         my $propname = beautify($+{PROPNAME});


### PR DESCRIPTION
At least for now, 5.17.1 adds this warning:

  Unescaped left brace in regex is deprecated, passed through in regex

Non-quantifier non-parameter braces need to be escaped.  The { in a
qr{} can't be escaped for nasty tokenizer reasons, so instead the qr{}
here has been switched to a qr<>, clearing up the warning on 5.17.1
