### PR TITLE
issue #2: add MIME::Charset to list of test prereqs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -67,7 +67,8 @@ my %WriteMakefile = (
 		},
 
 	'TEST_REQUIRES' => {
-		'Test::More' => '0.94',
+		'Test::More'    => '0.94',
+		'MIME::Charset' => '0.011.1',
 		},
 
 	'PREREQ_PM'     => {


### PR DESCRIPTION
It is needed by two of the tests in compile.t, but unless it is listed
under TEST_REQUIRES in Makefile.PL the user doesn't find out about the
prereq until the tests fail.

With this change (and a version of ExtUtils::MakeMaker >= 7.06) the
user sees the following upon running 'perl Makefile.PL':

     Warning: prerequisite MIME::Charset v0.11.1 not found.

Note that version 0.11.1 was chosen as being not too ancient and is
what is currently shipping in Debian stable (jessie).