### PR TITLE
Stop using printf() with no formatting codes

### DIFF
--- a/script/uninames
+++ b/script/uninames
@@ -117,7 +117,7 @@ sub main() {
             no warnings "utf8";
 	    my $chr = chr($ord);
             if ($chr =~ /[\pC\pZ]/) {
-                printf("--- ",   $ord);
+                print("--- ",   $ord);
             }
             else {
 		print " " if $chr =~ /\p{BC=NSM}/;

--- a/script/uniprops
+++ b/script/uniprops
@@ -217,7 +217,7 @@ ARG: for (@ARGV) {
             if (/^\p{HexDigit}+$/) {
                 $codepoint = hex();
             } else {
-                printf STDERR "$0: no character named ". quote($_). "\n";
+                print STDERR "$0: no character named ". quote($_). "\n";
                 $Errors++;
                 next ARG;
             }
@@ -367,7 +367,7 @@ EO_WARNING
         if ($@ =~ /is illegal/) {
             chomp $@;
             $@ =~ s/ at \S+ line \d+//;
-            printf STDERR "$0: $@\n";
+            print STDERR "$0: $@\n";
             $Errors++;
             # return;
         }


### PR DESCRIPTION
The first case produces a "Redundant argument in printf" warning under
(at least) 5.24.  The other two cases I saw when auditing for more
instances like the first.  They don't produce a warning, but printf()
isn't necessary either.
